### PR TITLE
Add initialOpen Parameter Support

### DIFF
--- a/build/middleware.js
+++ b/build/middleware.js
@@ -2931,7 +2931,8 @@ var __ = wp.i18n.__;
 function color(props, config, attributeKey) {
 	var defaultAttributes = {
 		value: props.attributes[attributeKey] || '',
-		label: __('Color')
+		label: __('Color'),
+		initialOpen: false
 	};
 
 	var fieldAttributes = _.extend(defaultAttributes, config);
@@ -2950,7 +2951,7 @@ function color(props, config, attributeKey) {
 
 	return wp.element.createElement(
 		PanelColor,
-		{ title: fieldAttributes.label, colorValue: fieldAttributes.value },
+		{ title: fieldAttributes.label, colorValue: fieldAttributes.value, initialOpen: fieldAttributes.initialOpen },
 		wp.element.createElement(ColorPalette, fieldAttributes)
 	);
 }
@@ -2988,7 +2989,9 @@ function dateTime(props, config, attributeKey) {
 
 		is12Hour: is12HourTime,
 
-		label: __('Date')
+		label: __('Date'),
+
+		initialOpen: false
 	};
 
 	var fieldAttributes = _.extend(defaultAttributes, config);
@@ -3014,7 +3017,7 @@ function dateTime(props, config, attributeKey) {
 
 	return wp.element.createElement(
 		PanelBody,
-		{ initialOpen: false, title: [label + ': ', wp.element.createElement(
+		{ initialOpen: fieldAttributes.initialOpen, title: [label + ': ', wp.element.createElement(
 				'span',
 				{ key: 'label' },
 				getFormattedDate()

--- a/examples/blocks.js
+++ b/examples/blocks.js
@@ -198,6 +198,7 @@ registerBlockType( 'gb-m-example/simple-block', {
 				type: 'color',
 				label: __( 'Button Background Color' ),
 				placement: 'inspector',
+				initialOpen: true,
 			},
 		},
 		buttonColor: {
@@ -206,6 +207,7 @@ registerBlockType( 'gb-m-example/simple-block', {
 				type: 'color',
 				label: __( 'Button Color' ),
 				placement: 'inspector',
+				initialOpen: false,
 			},
 		},
 		buttonClasses: {
@@ -275,6 +277,7 @@ registerBlockType( 'gb-m-example/simple-block', {
 			field: {
 				type: 'color',
 				placement: 'inspector',
+				initialOpen: true,
 			},
 		},
 		dateTime: {
@@ -282,6 +285,7 @@ registerBlockType( 'gb-m-example/simple-block', {
 			field: {
 				type: 'date-time',
 				placement: 'inspector',
+				initialOpen: false,
 			},
 		},
 		textarea: {

--- a/middleware/fields/color/index.js
+++ b/middleware/fields/color/index.js
@@ -10,6 +10,7 @@ export default function color( props, config, attributeKey ) {
 	const defaultAttributes = {
 		value: props.attributes[ attributeKey ] || '',
 		label: __( 'Color' ),
+		initialOpen: false,
 	};
 
 	const fieldAttributes = _.extend( defaultAttributes, config );
@@ -27,7 +28,7 @@ export default function color( props, config, attributeKey ) {
 	delete fieldAttributes.type;
 
 	return (
-		<PanelColor title={ fieldAttributes.label } colorValue={ fieldAttributes.value } >
+		<PanelColor title={ fieldAttributes.label } colorValue={ fieldAttributes.value } initialOpen={ fieldAttributes.initialOpen }>
 			<ColorPalette
 				{ ...fieldAttributes }
 			/>

--- a/middleware/fields/date-time/index.js
+++ b/middleware/fields/date-time/index.js
@@ -23,6 +23,8 @@ export default function dateTime( props, config, attributeKey ) {
 		is12Hour: is12HourTime,
 
 		label: __( 'Date' ),
+
+		initialOpen: false,
 	};
 
 	const fieldAttributes = _.extend( defaultAttributes, config );
@@ -47,7 +49,7 @@ export default function dateTime( props, config, attributeKey ) {
 	delete fieldAttributes.label;
 
 	return (
-		<PanelBody initialOpen={ false } title={ [
+		<PanelBody initialOpen={ fieldAttributes.initialOpen } title={ [
 			label + ': ',
 			<span key="label">{ getFormattedDate() }</span>,
 		]


### PR DESCRIPTION
This PR contains,

1. initialOpen parameter support for `PanelColor` which used for `color` field
2. initialOpen parameter support for `PanelBody` which used for `date-time` field
3. Update examples accordingly 