### PR TITLE
Fix: PHP Fatal Error

### DIFF
--- a/examples/server-side-registration/example.php
+++ b/examples/server-side-registration/example.php
@@ -4,6 +4,11 @@
  * Enqueue Example Block scripts.
  */
 function gutenberg_fields_middleware_server_side_registration_example() {
+
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
+
 	wp_register_script(
 		'gutenberg-middleware-server-side-examples',
 		plugins_url( 'blocks.js', __FILE__ ),


### PR DESCRIPTION
This PR fix the fatal error which is coming while `gutenberg` plugin is not active.